### PR TITLE
correction in tokenizer and dates_de in order to accept month names i…

### DIFF
--- a/data/de/tokenizer.dat
+++ b/data/de/tokenizer.dat
@@ -25,18 +25,19 @@ INDEX_SEQUENCE   0  (\.{4,}|-{2,}|\*{2,}|_{2,}|/{2,})
 INITIALS1 	 1  ([A-Z](\.[A-Z])+)(\.\.\.)
 INITIALS2 	 0  ([A-Z]\.)+
 TIMES            0  (([01]?[0-9]|2[0-4]):[0-5][0-9])
+DAYNUMS		 1  ([0-3]?[0-9]\.)\s*(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember) CI
 NAMES_CODES	 0  ({ALPHA}|{SYMNUM})*[0-9]({ALPHA}|[0-9]|{SYMNUM}+{ALPHANUM})*
 THREE_DOTS 	 0  (\.\.\.)
 QUOTES	         0  (``|<<|>>|'')
 MAILS 	         0  {ALPHANUM}+([\._]{ALPHANUM}+)*@{ALPHANUM}+([\._]{ALPHANUM}+)*
 URLS1 	         0  ((mailto:|(news|http|https|ftp|ftps)://)[\w\.\-/]+|^(www(\.[\w\-/]+)+))
 URLS2            1  ([\w\.\-/]+\.(com|org|net))[\s]
-CONTRACT_0a      1  (i'(m|d|ll|ve))({NOALPHANUM}|$) CI
-CONTRACT_0b      1  ((you|we|they|who)'(d|ll|ve|re))({NOALPHANUM}|$) CI
-CONTRACT_0c      1  ((he|she|it|that|there)'(d|ll|s))({NOALPHANUM}|$) CI
-CONTRACT_0d      1  ((let|what|where|how|who)'s)({NOALPHANUM}|$) CI
-CONTRACT1        1  ({ALPHA}+)('([sdm]|ll|ve|re)({NOALPHANUM}|$)) CI
-CONTRACT2        1  ('([sdm]|ll|ve|re|tween))({NOALPHANUM}|$) CI
+##CONTRACT_0a      1  (i'(m|d|ll|ve))({NOALPHANUM}|$) CI
+##CONTRACT_0b      1  ((you|we|they|who)'(d|ll|ve|re))({NOALPHANUM}|$) CI
+##CONTRACT_0c      1  ((he|she|it|that|there)'(d|ll|s))({NOALPHANUM}|$) CI
+##CONTRACT_0d      1  ((let|what|where|how|who)'s)({NOALPHANUM}|$) CI
+##CONTRACT1        1  ({ALPHA}+)('([sdm]|ll|ve|re)({NOALPHANUM}|$)) CI
+##CONTRACT2        1  ('([sdm]|ll|ve|re|tween))({NOALPHANUM}|$) CI
 KEEP_COMPOUNDS   0  {ALPHA}+(['_\-\+]{ALPHA}+)+
 *ABREVIATIONS1   0  (({ALPHA}+\.)+)(?!\.\.)
 WORD             0  {ALPHANUM}+[\+]*

--- a/src/include/freeling/morfo/dates_modules.h
+++ b/src/include/freeling/morfo/dates_modules.h
@@ -87,7 +87,7 @@ namespace freeling {
   const std::wstring RE_TIME2_CY=L"^(?:((?:[0-5])?(?:\\d))(?:munud|mun\\.?|m\\.?))$";
 
  // German:
-  const std::wstring RE_DATE_DE=L"^(?:(?:((?:[0-3])?(?:\\d))[/\\.] ?)(?:((?:(?:[0-1])?(?:\\d))|januar|februar|märz|april|mai|juni|juli|august|september|oktober|november|dezember|jan|feb|märz|apr|mai|jun|jul|aug|sep|okt|nov|dez)[/\\.] ?)(\\d{1,4}))$";
+  const std::wstring RE_DATE_DE=L"^(?:(?:((?:[0-3])?(?:\\d))[/\\.] ?)(?:((?:(?:[0-1])?(?:\\d))|[Jj]anuar|[Ff]ebruar|[Mm]ärz|[Aa]pril|[Mm]ai|[jJ]uni|[jJ]uli|[aA]ugust|[Ss]eptember|[oO]ktober|[nN]ovember|[Dd]ezember|jan|feb|märz|apr|mai|jun|jul|aug|sep|okt|nov|dez)[/\\.] ?)(\\d{1,4}))$";
   const std::wstring RE_TIME1_DE=L"^(?:((?:(?:[0-1])?(?:\\d))|(?:2(?:[0-4])))(?:h|:)(?:((?:[0-5])?(?:\\d))(?:minuten|min|m)?)?)$";
   const std::wstring RE_TIME2_DE=L"^(?:((?:[0-5])?(?:\\d))(?:minuten|min\\.?|m\\.?))$";
 

--- a/src/libfreeling/dates/dates_de.cc
+++ b/src/libfreeling/dates/dates_de.cc
@@ -281,6 +281,7 @@ namespace freeling {
 	trans[ST_read_um][TK_time] = ST_read_time;
 
 	// state read_hour (2)
+	trans[ST_read_hour][TK_w_Monat] = ST_read_month;
 	trans[ST_read_hour][TK_w_Uhr] = ST_read_Uhr;
 	trans[ST_read_hour][TK_w_nach] = ST_read_nach;
 	trans[ST_read_hour][TK_w_point] = ST_read_OrdPoint; // this means we have read a day and not an hour
@@ -315,6 +316,7 @@ namespace freeling {
 	trans[ST_read_am][TK_day] = ST_read_ord;
 
 	// state read_ord (13)
+	trans[ST_read_ord][TK_w_Monat] = ST_read_month;
 	trans[ST_read_ord][TK_w_point] = ST_read_OrdPoint;
 
 	// state read_month (14)
@@ -442,9 +444,9 @@ namespace freeling {
 	    break;
 
 	case ST_read_am:
-	    TRACE(3,L"check Match DATE (h+m) regex." + form);
+	    TRACE(3,L"check Match DATE regex." + form);
 	    if (RE_Date.search(form,st->rem)) {		
-		TRACE(3,L"Match DATE (h+m) regex.");
+		TRACE(3,L"Match DATE regex.");
 		//for (unsigned int i = 0; i < st->rem.size(); ++i) {
 		//    //TRACE(3,L" RE " + i + L" " + st->rem[i]);
 		//    wcerr << L" RE " <<i << L" " << st->rem[i] << endl;
@@ -645,6 +647,12 @@ namespace freeling {
 	    if (token==TK_w_Monat) {
 		TRACE(3,L"Actions for state ST_read_month");
 		st->month = util::int2wstring(nMes.find(form)->second);
+		// eventually correct preceding token which was possibly mal-interpreted as hour
+		if (st->hour != L"" && st->hour != L"??") {
+		    //wcerr << st->hour << L" " << st->day << endl;
+		    st->day = st->hour;
+		    st->hour = L"";
+		}
 	    }
 	    break;
 	case ST_read_date:
@@ -664,6 +672,7 @@ namespace freeling {
 	    st->month = util::int2wstring(nMes.find(form)->second);
 	    break;
 	}
+	TRACE(3,L"Reach Actions finished");
     }
 
     ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
correction in tokenizer and dates_de in order to accept month names in capital after an ordinal (like 20.) without splitter incorrectly detecting sentence end. Dates like
  am Montag den 3. April 2016.
  Samstag den 4. Mai 1999.

are correctly detected 