### PR TITLE
Fix Java JNI build description & workflow.

### DIFF
--- a/APIs/java/Dockerfile
+++ b/APIs/java/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:trusty-20160711
+MAINTAINER Alexander Merkulov <sasha@merqlove.ru>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -qq update 
+
+# Language setup
+RUN apt-get -qqy install language-pack-en-base && \
+    update-locale LANG=en_US.UTF-8 && \
+    echo "LANGUAGE=en_US.UTF-8" >> /etc/default/locale && \
+    echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+
+# Java Deps
+RUN apt-get install -qq -y software-properties-common curl && \
+    apt-get -qqy install git build-essential --fix-missing && \
+    add-apt-repository ppa:webupd8team/java && apt-get -qq update && \
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
+    apt-get install -qq -y oracle-java8-installer
+
+# Freeling Deps
+RUN locale-gen en_US.UTF-8 && \
+    apt-get install -y automake autoconf libtool wget swig \
+                       libicu52 libboost-regex1.55.0 \
+                       libboost-system1.55.0 libboost-program-options1.55.0 \
+                       libboost-thread1.55.0 libboost-filesystem1.55.0 && \
+    apt-get install -y libicu-dev libboost-regex-dev libboost-system-dev \
+                       libboost-program-options-dev libboost-thread-dev \
+                       zlib1g-dev
+
+# Install Freeling
+RUN cd /tmp && \
+    wget -q --progress=dot:giga https://github.com/TALP-UPC/FreeLing/releases/download/4.0/freeling-4.0-trusty-amd64.deb && \
+    dpkg -i freeling-4.0-trusty-amd64.deb
+
+# BUILD JNI
+ENV JAVADIR /usr/lib/jvm/java-8-oracle
+ENV SWIGDIR /usr/share/swig2.0
+ENV FREELINGDIR /usr
+ENV FREELINGOUT /usr/local/lib
+
+RUN cd /tmp && \
+    git clone -q https://github.com/cnsa/freeling-api.git && \
+    cd /tmp/freeling-api/APIs/java && \
+    make all
+
+# Cleanup
+RUN sudo rm -f /tmp/freeling-4.0-trusty-amd64.deb && \
+    sudo apt-get autoremove -y && \
+    sudo apt-get clean -y
+
+WORKDIR /
+

--- a/APIs/java/Makefile
+++ b/APIs/java/Makefile
@@ -4,17 +4,19 @@
 #     make FREELINGDIR=/my/freeling/dir SWIGDIR=/my/swig/dir JAVADIR=/my/java/dir
 
 # freeling *installation* directory (not source!)
-FREELINGDIR = /usr/local
+FREELINGDIR ?= /usr/local
+# Output directory for compiled library & JNI
+FREELINGOUT ?= .
 # swig and java location in your system
-SWIGDIR = /usr/share/swig2.0
-JAVADIR = /usr/lib/jvm/default-java
+SWIGDIR ?= /usr/share/swig2.0
+JAVADIR ?= /usr/lib/jvm/default-java
 
 # you may change the package name if you want
 PACKAGE = edu/upc/freeling
 JPACKAGE = edu.upc.freeling
 
 # Change your compiler, if necessary.
-GCC=g++
+GCC ?= g++
 
 all: freeling_javaAPI.cxx libfreeling_javaAPI.so
 
@@ -22,15 +24,16 @@ all: freeling_javaAPI.cxx libfreeling_javaAPI.so
 
 # Compile the C++ API
 libfreeling_javaAPI.so: freeling_javaAPI.cxx
-	$(GCC) -shared -o libfreeling_javaAPI.so freeling_javaAPI.cxx -lfreeling -L$(FREELINGDIR)/lib -I$(FREELINGDIR)/include -I$(FREELINGDIR)/include/treeler -I$(JAVADIR)/include -I$(JAVADIR)/include/linux -fPIC -std=c++0x
+	$(GCC) -shared -o $(FREELINGOUT)/libfreeling_javaAPI.so freeling_javaAPI.cxx -lfreeling -L$(FREELINGDIR)/lib -lboost_system -I$(FREELINGDIR)/include -I$(FREELINGDIR)/include/treeler -I$(JAVADIR)/include -I$(JAVADIR)/include/linux -fPIC -std=c++0x
 	$(JAVADIR)/bin/javac $(PACKAGE)/*.java
-	$(JAVADIR)/bin/jar -cf freeling.jar $(PACKAGE)
+	$(JAVADIR)/bin/jar -cf $(FREELINGOUT)/freeling.jar $(PACKAGE)
 
 # Build the Java JNI wrapper classes.
 freeling_javaAPI.cxx: freeling_javaAPI.i ../common/freeling.i
 	rm -rf $(PACKAGE)
 	mkdir -p $(PACKAGE)
+	mkdir -p $(FREELINGOUT)
 	swig -java -c++ -package $(JPACKAGE) -outdir $(PACKAGE) -o freeling_javaAPI.cxx -I$(SWIGDIR)/java -I$(SWIGDIR)/std -I$(SWIGDIR) freeling_javaAPI.i
 
 clean:
-	rm -rf *.jar *.so *.dylib *.cxx *.class edu
+	rm -rf $(FREELINGOUT)/*.jar $(FREELINGOUT)/*.so $(FREELINGOUT)/*.dylib *.cxx *.class edu

--- a/APIs/java/Makefile.MacOSX
+++ b/APIs/java/Makefile.MacOSX
@@ -8,18 +8,25 @@
 
 # freeling *installation* directory (not source!). 
 # It will be /usr/local unless you used `./configure --prefix=/some/other/place`
-FREELINGDIR = /usr/local
+FREELINGDIR ?= /usr/local
+# Output directory for compiled library & JNI
+FREELINGOUT ?= .
 # swig and java location in your system
-SWIGDIR = /opt/local/share/swig/3.0.8
-JAVADIR = /System/Library/Frameworks/JavaVM.framework
-JAVABIN = $(JAVADIR)/Versions/Current/Commands
+SWIGDIR ?= /opt/local/share/swig/3.0.8
+JAVADIR ?= /System/Library/Frameworks/JavaVM.framework
+JAVABIN ?= $(JAVADIR)/Versions/Current/Commands
+JAVAHEADERS ?= -I$(JAVADIR)/Headers
+ICU4CDIR ?= /usr/local/opt/icu4c
+SYSTEMLIBS ?= "-L/opt/local/lib"
+SYSTEMHEADERS ?= "-I/opt/local/include"
+
 
 # you may change the package name if you want
 PACKAGE = edu/upc/freeling
 JPACKAGE = edu.upc.freeling
 
 # Change your compiler, if necessary.
-GCC=g++
+GCC ?= g++
 
 all: freeling_javaAPI.cxx libfreeling_javaAPI.dylib
 
@@ -27,15 +34,16 @@ all: freeling_javaAPI.cxx libfreeling_javaAPI.dylib
 
 # Compile the C++ API
 libfreeling_javaAPI.dylib: freeling_javaAPI.cxx
-	$(GCC) -dynamiclib -o libfreeling_javaAPI.dylib freeling_javaAPI.cxx -lfreeling -L$(FREELINGDIR)/lib -I$(FREELINGDIR)/include -I$(FREELINGDIR)/include/treeler -I$(JAVADIR)/Headers -I/opt/local/include -L/opt/local/lib -fPIC -std=c++0x -lboost_system-mt
+	$(GCC) -dynamiclib -o $(FREELINGOUT)/libfreeling_javaAPI.dylib freeling_javaAPI.cxx -lfreeling -I$(ICU4CDIR)/include -L$(FREELINGDIR)/lib -I$(FREELINGDIR)/include -I$(FREELINGDIR)/include/treeler $(JAVAHEADERS) $(SYSTEMHEADERS) $(SYSTEMLIBS) -fPIC -std=c++0x -lboost_system-mt
 	$(JAVABIN)/javac $(PACKAGE)/*.java
-	$(JAVABIN)/jar -cf freeling.jar $(PACKAGE)
+	$(JAVABIN)/jar -cf $(FREELINGOUT)/freeling.jar $(PACKAGE)
 
 # Build the Java JNI wrapper classes.
 freeling_javaAPI.cxx: freeling_javaAPI.i ../common/freeling.i
 	rm -rf $(PACKAGE)
 	mkdir -p $(PACKAGE)
+	mkdir -p $(FREELINGOUT)
 	swig -java -c++ -package $(JPACKAGE) -outdir $(PACKAGE) -o freeling_javaAPI.cxx -I$(SWIGDIR)/java -I$(SWIGDIR)/std -I$(SWIGDIR) freeling_javaAPI.i
 
 clean:
-	rm -rf *.jar *.dylib *.cxx *.class edu 
+	rm -rf $(FREELINGOUT)/*.jar $(FREELINGOUT)/*.dylib *.cxx *.class edu 

--- a/APIs/java/README.Unix.md
+++ b/APIs/java/README.Unix.md
@@ -1,0 +1,50 @@
+## Build Freeling Java API under Linux/MacOS
+
+### HOW TO BUILD THE API
+
+  1. [Install FreeLing](https://talp-upc.gitbooks.io/freeling-user-manual/content/installation.html)
+
+    - OSX: `brew install freeling`
+    - Linux: Able to install via packages.
+
+  2. [Install Java SDK and JNI headers](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+
+  3. Set/Edit Your ENV variables, which in the Makefile:
+
+  Variable       | Description                                                       | Default                    |
+  :------------- | :---------------------------------------------------------------- | :------------------------- |
+  `FREELINGDIR`  | directory prefix where you installed freeling                     | /usr/local                 |
+  `FREELINGOUT`  | directory prefix where your lib will be placed                    | same directory             |
+  `SWIGDIR`      | directory where swig share files are installed in your system     | usr/local/share/swig2.0    |
+  `JAVADIR`      | directory where java is installed                                 | /usr/lib/jvm/java-7-oracle |
+
+  **OSX ONLY**
+
+  Variable         | Description                                   | Default                |
+  :--------------- | :-------------------------------------------- | :--------------------- |
+  `ICU4CDIR`       | directory where icu4c is installed            | /usr/local/opt/icu4c   |
+  `SYSTEMLIBS`     | directory where your additional libs is       | /opt/local/lib         |
+  `SYSTEMHEADERS`  | directory where your additional headers is    | /opt/local/include     |
+
+  4. Run `make` to build the java API.
+     > On `MacOS`, you need to use Makefile.MacOSX: `make -f Makefile.MacOSX`
+
+
+### HOW TO USE THE API FROM A JAVA PROGRAM
+
+  1. Make sure that the directory contanining `libfreeling.so` `($FREELINGDIR/lib)` is in your `LD_LIBRARY_PATH`
+
+  2. Make sure that the directory contanining `libfreeling_javaAPI.so` (created by `make` above) is in your `LD_LIBRARY_PATH`.
+
+  3. Make sure that the package `freeling.jar` created by make is in your CLASSPATH
+
+  4. Compile and execute the sample programs (or your own java program):
+
+         $ javac Analyzer.java
+         $ java Analyzer
+
+         $ javac SemGraph.java
+         $ java SemGraph
+
+ See FreeLing documentation and sample programs in src/main to
+ understand what this sample program is doing.

--- a/APIs/java/README.Win.md
+++ b/APIs/java/README.Win.md
@@ -1,0 +1,44 @@
+## Build Freeling Java API under WINDOWS
+
+### HOW TO BUILD THE API USING MSVC
+
+  1. Install java 
+
+  2. Download and install swig (http://www.swig.org/)
+
+  3. Run swig with freeling_javaAPI.i to generate the API
+     SWIG will generate a directory edu/upc/freeling with the Java API 
+     for all modules, and a file freeling_javaAPI.cxx with the JNI side 
+     of the API.
+
+  4. Compile java code in edu/upc/freeling and build a file `freeling.jar`
+     with the results.
+
+  5. Compile `freeling_javaAPI.cxx` into a DLL (using MSVC or any other compiler).
+     You'll need to provide paths to freeling and treeler include directories, 
+     and to Java headers (jni.h etc)
+     
+     You will get a freeling_javaAPI.dll library to be loaded from 
+     your Java programs
+
+
+### HOW TO USE THE API FROM A JAVA PROGRAM
+
+  1. Make sure `libfreeling.dll`, `libboost`, and `libicu` are in a path where 
+      they will be found.
+      > (e.g. set `PATH=%PATH%;C:\my\freeling\installation;C:\my\libicu\installation`)
+
+  2. Make sure `libfreeling_javaAPI.dll` (created by swig) is in a path 
+      where it will be found.
+      > (e.g. set `PATH=%PATH%;C:\my\freeling\javaAPI\installation`)
+
+  3. Make sure that the package `freeling.jar` created by make is in your `CLASSPATH`
+
+  4. Compile and execute the sample program (or your program): 
+  
+         C:\my\java\installation\javac.exe Analyzer.java
+         C:\my\java\installation\java.exe Analyzer
+
+ See FreeLing documentation and sample programs in src/main to
+ understand what this sample program is doing.
+

--- a/APIs/java/README.md
+++ b/APIs/java/README.md
@@ -1,0 +1,10 @@
+# Java API for Freeling library
+
+> This directory contains required files to generate a java API for FreeLing.
+
+- [Linux/MacOS](README.Unix.md)
+- [Windows](README.Win.md)
+
+ See FreeLing documentation and sample programs in src/main to
+ understand what this sample program is doing.
+


### PR DESCRIPTION
- Java doc's spliced into two sections: Unix/Win.
- Converted into Markdown.
- Added Docker container example with JNI inside.
Really nice way, if we don't build FreeLing inside the container, but use precompiled package.

This setup works for us inside OS X, and within Docker Ubuntu 14.04.