### PR TITLE
Fixed Python's API

### DIFF
--- a/APIs/common/freeling.i
+++ b/APIs/common/freeling.i
@@ -915,7 +915,7 @@ class paragraph : public std::list<freeling::sentence> {
     void set_type(mentionType);
     void set_initial(bool);
     void set_group(int);
-    void subsumed_with_no_verb(bool b=false);
+    void set_maximal(bool b);
 
     /// getters
     int get_id() const;
@@ -930,7 +930,7 @@ class paragraph : public std::list<freeling::sentence> {
     int get_group() const;
     bool is_type(mentionType) const;
     bool is_initial() const;
-    bool is_subsumed_with_no_verb() const;
+    bool is_maximal() const;
     parse_tree::const_iterator get_ptree() const;
     const word& get_head() const;
     std::wstring value() const;    


### PR DESCRIPTION
Python's API was not building.
Following [this](http://nlp.lsi.upc.edu/freeling/node/591) suggestion in the forum from a previous similar issue, fixed function names in APIs/common/freeling.i to match those in src/libfreeling/language.cc that were introduced in commit 7ce1850.
It builds OK now and Python imports the library successfully, although I didn't test it thoroughly afterwards.
Let me know if you need me to make any changes to the fix before merging.
Thanks