### PR TITLE
Add more templates for the iterator wrapper types

### DIFF
--- a/APIs/common/templates.i
+++ b/APIs/common/templates.i
@@ -33,7 +33,9 @@
 %template(ListSentenceIterator) ListIterator<freeling::sentence>;
 %template(ListWordIterator)     ListIterator<freeling::word>;
 %template(ListAnalysisIterator) ListIterator<freeling::analysis>;
+%template(ListAlternativeIterator) ListIterator<freeling::alternative>;
 %template(ListStringIterator) ListIterator<std::wstring>;
+%template(ListIntIterator) ListIterator<int>;
 #endif
 
 %template(ListString) std::list<std::wstring>;

--- a/APIs/common/templates.i
+++ b/APIs/common/templates.i
@@ -32,6 +32,8 @@
 %template(ListParagraphIterator) ListIterator<freeling::paragraph>;
 %template(ListSentenceIterator) ListIterator<freeling::sentence>;
 %template(ListWordIterator)     ListIterator<freeling::word>;
+%template(ListAnalysisIterator) ListIterator<freeling::analysis>;
+%template(ListStringIterator) ListIterator<std::wstring>;
 #endif
 
 %template(ListString) std::list<std::wstring>;


### PR DESCRIPTION
Some of the iterator wrapper types were missing on the Java API.