### PR TITLE
Fix Ruby API

### DIFF
--- a/APIs/common/templates.i
+++ b/APIs/common/templates.i
@@ -50,7 +50,9 @@
 #ifndef FL_API_PHP
 %template(VectorSetString) std::vector<std::set<std::wstring> >;
 %template(VectorSetInt) std::vector<std::set<int> >;
+#ifndef FL_API_RUBY
 %template(SetString) std::set<std::wstring>;
+#endif
 #endif
 #endif
 

--- a/APIs/ruby/Makefile
+++ b/APIs/ruby/Makefile
@@ -1,9 +1,8 @@
 
 # IMPORTANT: If you have FreeLing installed in a path other
-# than /usr/local, and/or your ruby version is different
-# than 2.5.0, you can call 'make' overriding variable values,
+# than /usr/local, you can call 'make' overriding variable values,
 # E.g.:
-#       make FREELINGDIR=/my/freeling/dir RUBYVER=ruby-X.X.X
+#       make FREELINGDIR=/my/freeling/dir
 
 # IMPORTANT:  Depending on how you installed ruby, you may get an
 # a compilation error about "ruby/config.h not found". If that
@@ -11,24 +10,18 @@
 # proper path to the "g++" line below.
 
 
-# these two variables may be overriden in the command
+# this variable may be overriden in the command
 # line as shown above
 FREELINGDIR = /usr/local
-RUBYVER = ruby-2.5.0
 
-## change this if you manually installed ruby somewhere else
-RUBYDIR = /usr/include/$(RUBYVER)
+## automatically detects the correct paths for Ruby
+RUBY_PATHS = -I$(shell ruby -rrbconfig -e 'puts RbConfig::CONFIG[%q{rubyhdrdir}]') -I$(shell ruby -rrbconfig -e 'puts RbConfig::CONFIG[%q{rubyarchhdrdir}]')
 
 freeling.so: freeling_rubyAPI.cxx
-	g++ -shared -o freeling.so freeling_rubyAPI.cxx -lfreeling -I$(FREELINGDIR)/include -L$(FREELINGDIR)/lib -I$(RUBYDIR) -I/usr/include/x86_64-linux-gnu/$(RUBYVER) -I$(RUBYDIR)/x86_64-linux -fPIC -std=gnu++0x
+	g++ -shared -o freeling.so freeling_rubyAPI.cxx -lfreeling -I$(FREELINGDIR)/include -L$(FREELINGDIR)/lib $(RUBY_PATHS) -fPIC -std=gnu++0x
 
 freeling_rubyAPI.cxx: freeling_rubyAPI.i
 	swig -ruby -c++ -o freeling_rubyAPI.cxx freeling_rubyAPI.i
-	cat freeling_rubyAPI.cxx \
-	| sed 's/make_set_nonconst_iterator/make_nonconst_iterator/' \
-	| sed 's/value_type& dst = \*base::current;/value_type dst = *base::current;/' \
-	> tmp; \
-	mv tmp freeling_rubyAPI.cxx
 
 clean:
 	rm -f freeling_rubyAPI.cxx freeling.so

--- a/APIs/ruby/README
+++ b/APIs/ruby/README
@@ -1,7 +1,23 @@
 
- This folder contains a Makefile to build a Ruby API for FreeLing using SWIG.
+  ##### Ruby API for FreeLing    ######
 
- However, SWIG supports ruby only partially, thus the Makefile contains a series of hacks that may need adjusting.
 
- Please read carefully the comments in the Makefile and perform the required adjustments before running it.
+  INSTALLATION
+
+  To get a ruby API library, after installing FreeLing, follow the steps:
+
+   1.- Edit Makefile in this directory to adjust the right values of
+        FREELINGDIR: must be your FreeLing installation directory --e.g. /usr/local
+
+   2. issue 'make' to compile the ruby API
+
+   3. Make sure that the directory contanining libfreeling.so (FREELINGDIR/lib) is
+      in your LD_LIBRARY_PATH.
+
+   4. Test the interface with the "sample.rb" script in this directory
+      (after editing it to adjust FLDIR)
+
+   USAGE
+
+    - Write your ruby programms using freeling as seen in sample.rb
 

--- a/APIs/ruby/freeling_rubyAPI.i
+++ b/APIs/ruby/freeling_rubyAPI.i
@@ -42,66 +42,16 @@
  using namespace std;
 %}
 
-
-%fragment("SWIG_AsWCharPtrAndSize","header",fragment="<wchar.h>",fragment="SWIG_pwchar_descriptor") {
-SWIGINTERN int SWIG_AsWCharPtrAndSize(VALUE obj, wchar_t **cptr, size_t *psize, int *alloc)
-{
-  if (TYPE(obj) == T_STRING) {
-    %#if defined(StringValuePtr)
-                  char *cstr = StringValuePtr(obj);
-    %#else
-       char *cstr = STR2CSTR(obj);
-    %#endif
-
-       std::wstring tempStr = freeling::util::string2wstring(cstr);
-
-    size_t size = tempStr.size() + 1;
-    if (cptr)  {
-      if (alloc) {                
-        *cptr = %new_copy_array(tempStr.c_str(), size, wchar_t);
-        *alloc = SWIG_NEWOBJ;
-      }
-    }
-    if (psize) *psize = size;
-    return SWIG_OK;
-  } else {
-    swig_type_info* pwchar_descriptor = SWIG_pwchar_descriptor();
-    if (pwchar_descriptor) {
-      void* vptr = 0;
-      if (SWIG_ConvertPtr(obj, &vptr, pwchar_descriptor, 0) == SWIG_OK) {
-        if (cptr) *cptr = (wchar_t *)vptr;
-        if (psize) *psize = vptr ? (wcslen((wchar_t*)vptr) + 1) : 0;
-        if (alloc) *alloc = SWIG_OLDOBJ;
-        return SWIG_OK;
-      }
-    }
-  }  
-  return SWIG_TypeError;
-}
- }
-
-%fragment("SWIG_FromWCharPtrAndSize","header",fragment="<wchar.h>",fragment="SWIG_pwchar_descriptor") {
-SWIGINTERNINLINE VALUE
-  SWIG_FromWCharPtrAndSize(const wchar_t * carray, size_t size)
-{
-  if (carray) {
-    std::string tempStr(freeling::util::wstring2string(carray));
-
-    if (tempStr.size() > LONG_MAX) {
-      swig_type_info* pwchar_descriptor = SWIG_pwchar_descriptor();
-      return pwchar_descriptor ?
-        SWIG_NewPointerObj(%const_cast(carray,wchar_t *), pwchar_descriptor, 0) : Qnil;
-    } else {
-      return rb_str_new(tempStr.c_str(), %numeric_cast(tempStr.size(),long));
-    }
-  } else {
-    return Qnil;
-  }
-}
- }
+%include std_wstring.i
+%include std_set.i
 
 %include <typemaps/cwstring.swg>
 %include <typemaps/std_wstring.swg>
 
+// `SetString` is also defined in `freeling.i`, but it needs to be defined earlier, otherwise
+// SWIG will complain about `make_set_nonconst_iterator` not having been defined yet.
+%template(SetString) std::set<std::wstring>;
+
+#define FL_API_RUBY
 %include ../common/templates.i
 %include ../common/freeling.i


### PR DESCRIPTION
- The Ruby API makefile now compiles without any "hacks"
- The ruby version and path is now automatically detected
- The SWIG interface file for the Ruby API now includes modules from the SWIG library, instead of defining custom fragments inline
- The ruby sample code has been updated with clearer variable names to make it easier for people to understand and customize
- The readme has been updated to reflect that the Ruby API now is working (the content was mostly copied from the Python API readme)
- These changes also fixes #83, where the API would crash on non-ascii characters