### PR TITLE
Fix static linking: all variables need to be defined

### DIFF
--- a/src/libdynet/dynet/CMakeLists.txt
+++ b/src/libdynet/dynet/CMakeLists.txt
@@ -207,9 +207,6 @@ set(dynet_gpu_SRCS
     gpu-ops.cu)
 
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cc)
-if (NOT MSVC)
-  set(BUILD_SHARED_LIBS ON)
-endif()
 
 #foreach(test_src ${TEST_SRCS})
   #Extract the filename without an extension (NAME_WE)

--- a/src/libfoma/foma/foma.h
+++ b/src/libfoma/foma/foma.h
@@ -25,8 +25,8 @@
 #define PROMPT_A 1    /* Apply prompt   */
 
 #ifdef MAIN_MODULE  
-struct defined_networks   *g_defines;
-struct defined_functions  *g_defines_f;
+struct defined_networks   *g_defines = 0;
+struct defined_functions  *g_defines_f = 0;
 #else
 extern struct defined_networks   *g_defines;
 extern struct defined_functions  *g_defines_f;


### PR DESCRIPTION
closes https://github.com/TALP-UPC/FreeLing/issues/96

In order to link statically all the `extern` variables need to be defined (we cannot fool the compiler). These variables were originally defined in the [`main()` function in `foma.c`](https://github.com/mhulden/foma/blob/e20a453a318128973d75753f9ecbef0e6b82b23f/foma/foma.c#L96), but this function was removed. Maybe to use `foma` as a library some of these files are not needed, this is something we could investigate.

I hope these changes don't break anything