### PR TITLE
Use CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,8 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 project(FreeLing)
-set(PACKAGE_NAME "FreeLing") 
 set(VERSION "4.1") 
-set(PACKAGE_STRING "\"${PACKAGE_NAME} ${VERSION}\"")
+set(PACKAGE_STRING "\"${CMAKE_PROJECT_NAME} ${VERSION}\"")
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib") # Needed to find libraries if not installed in system path
 
 # Add compiler definitions
@@ -28,10 +27,9 @@ option(TRACES "Enable traces" OFF)
 option(WARNINGS "Enable warnings" ON)
 option(XPRESSIVE "Xpressive regex" OFF)
 option(JAVA_API "Build Java API" OFF)
-option(JAVA_API "Build Java API" OFF)
 option(PERL_API "Build Perl API" OFF)
 option(PYTHON2_API "Build Python 2.7 API" OFF)
-option(PERL_API "Build Perl API" OFF)
+option(PYTHON3_API "Build Python 3 API" OFF)
 
 # Check for dependencies -- ZLIB
 find_package(ZLIB REQUIRED)
@@ -63,11 +61,11 @@ endif()
 install(DIRECTORY data/
         DESTINATION share/freeling
         PATTERN "dictionary" EXCLUDE
-	PATTERN "parameters.*.gz.*" EXCLUDE
-	PATTERN "model*.gz.*" EXCLUDE
-	PATTERN "*embeddings*.gz.*" EXCLUDE
-	PATTERN "model*.crf.*" EXCLUDE
-	PATTERN "Makefile*" EXCLUDE)
+        PATTERN "parameters.*.gz.*" EXCLUDE
+        PATTERN "model*.gz.*" EXCLUDE
+        PATTERN "*embeddings*.gz.*" EXCLUDE
+        PATTERN "model*.crf.*" EXCLUDE
+        PATTERN "Makefile*" EXCLUDE)
 
 #### Data installation hooks
 SET(languages "as;ca;cs;cy;de;en;es;fr;gl;hr;it;nb;pt;ru;sl")

--- a/src/libdynet/CMakeLists.txt
+++ b/src/libdynet/CMakeLists.txt
@@ -126,13 +126,6 @@ if(ENABLE_BOOST)
   set(Boost_REALPATH ON)
   find_package(Boost COMPONENTS program_options regex serialization REQUIRED)
   message("-- Boost dir is " ${Boost_INCLUDE_DIR})
-  include_directories(${Boost_INCLUDE_DIR})
-  if(MSVC)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LIBPATH:${Boost_LIBRARY_DIRS}")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LIBPATH:${Boost_LIBRARY_DIRS}")
-  else()
-    set(LIBS ${LIBS} ${Boost_LIBRARIES})
-  endif()
 endif()
 
 if(BACKEND)
@@ -171,17 +164,10 @@ if (WITH_CUDA_BACKEND)
 endif()
 
 # look for Eigen
-if (DEFINED ENV{EIGEN3_INCLUDE_DIR} AND NOT DEFINED EIGEN3_INCLUDE_DIR) # use env variable if not set
-  set(EIGEN3_INCLUDE_DIR $ENV{EIGEN3_INCLUDE_DIR})
-endif()
-get_filename_component(EIGEN3_INCLUDE_DIR "${EIGEN3_INCLUDE_DIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
-set(EIGEN3_INCLUDE_DIR ${EIGEN3_INCLUDE_DIR} CACHE STRING "" FORCE)
-message("-- Eigen dir is " ${EIGEN3_INCLUDE_DIR})
 find_package(Eigen3 REQUIRED)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
-FIND_PACKAGE(Threads REQUIRED)
-set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+find_package(Threads REQUIRED)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/src/libdynet/dynet/CMakeLists.txt
+++ b/src/libdynet/dynet/CMakeLists.txt
@@ -292,11 +292,11 @@ if(WITH_CUDA_BACKEND)
     target_compile_definitions(dynet PRIVATE HAVE_CUDNN)
   endif()
   cuda_add_cublas_to_target(dynet)
-  target_link_libraries(dynet ${LIBS})
+  target_link_libraries(dynet ${Boost_LIBRARIES} Eigen3::Eigen3 Threads::Threads)
 else()
   # Build cpu library
   add_library(dynet ${dynet_library_SRCS} ${dynet_library_HDRS})
-  target_link_libraries(dynet ${LIBS})
+  target_link_libraries(dynet ${Boost_LIBRARIES} Eigen3::Eigen3 Threads::Threads)
 endif(WITH_CUDA_BACKEND)
 
 install(FILES ${dynet_library_HDRS} DESTINATION include/dynet)

--- a/src/libfoma/CMakeLists.txt
+++ b/src/libfoma/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include_directories( ${ZLIB_INCLUDE_DIRS} )
-
 if (WIN32)
   add_definitions(-DFOMA_EXPORTS=1 -D_CRT_SECURE_NO_WARNINGS=1 -D_CRT_NONSTDC_NO_DEPRECATE=1 -DYY_NO_UNISTD_H=1 -DNDEBUG=1 -D_WINDOWS=1 -D_USRDLL=1 -DLIBFOMA_EXPORTS=1 -DWIN32=1)
 endif()
@@ -10,7 +8,7 @@ foma/apply.c foma/coaccessible.c foma/constructions.c foma/define.c foma/determi
 )
 
 add_library(foma ${sources})
-target_link_libraries(foma ${ZLIB_LIBRARIES})
+target_link_libraries(foma ZLIB::ZLIB)
 set_target_properties(foma PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(foma PUBLIC .)
 

--- a/src/libfreeling/CMakeLists.txt
+++ b/src/libfreeling/CMakeLists.txt
@@ -1,11 +1,4 @@
 
-include_directories(${Boost_INCLUDE_DIRS})
-include_directories(${ICU_INCLUDE_DIRS})
-include_directories(${ZLIB_INCLUDE_DIRS})
-
-link_directories(${Boost_LIBRARY_DIRS})
-link_directories(${ICU_LIBRARY_DIRS})
-
 if (WIN32)
    # compiler definitions for windows
    add_definitions(-DFL_EXPORTS=1 -D_CRT_SECURE_NO_WARNINGS=1 -D_CRT_NONSTDC_NO_DEPRECATE=1 -DNOMINMAX -DNDEBUG=1 -D_WINDOWS=1 -D_USRDLL=1 -DLIBFREELING_EXPORTS=1 -DWIN32=1)
@@ -39,7 +32,7 @@ version.cc util.cc regexp.cc traces.cc language.cc configfile.cc analyzer.cc ana
 )
 
 add_library(freeling ${freeling_SRCS})
-target_link_libraries(freeling foma treeler dynet crfsuite ${Boost_LIBRARIES} ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY})
+target_link_libraries(freeling foma treeler dynet crfsuite ${Boost_LIBRARIES} ICU::ICU)
 
 install(TARGETS freeling
         RUNTIME DESTINATION bin

--- a/src/libtreeler/CMakeLists.txt
+++ b/src/libtreeler/CMakeLists.txt
@@ -3,8 +3,6 @@ file(GLOB_RECURSE treeler_SRC
 treeler/base/token.cc treeler/base/fidx.cc treeler/base/dictionary.cc treeler/util/options.cc treeler/util/char-utils.cc treeler/util/timer.cc treeler/io/io-basic.cc treeler/control/factory-base.cc treeler/dep/part-dep1.cc treeler/dep/parser-projdep1.cc treeler/dep/part-dep2.cc treeler/dep/part-dep2-index.cc treeler/dep/parser-projdep2.cc treeler/dep/pos-symbols.cc treeler/dep/dependency_parser.cc treeler/tag/part-tag.cc treeler/tag/tuple-seq.cc treeler/tag/io-tag.cc treeler/class/class-basic.cc treeler/class/io-class.cc treeler/class/fgen-class.cc treeler/class/model-mc.cc treeler/srl/part-srl0.cc treeler/srl/simple-parser.cc treeler/srl/srl_parser.cc 
 )
 
-include_directories( ${ZLIB_INCLUDE_DIRS} )
-
 if (WIN32)
   list(APPEND treeler_SRC treeler/base/windll.cc)
   add_definitions(-DTREELER_EXPORTS=1 -D_CRT_SECURE_NO_WARNINGS=1 -DNDEBUG=1 -D_WINDOWS=1 -DWIN32=1 -DNOMINMAX=1)
@@ -21,7 +19,7 @@ endif()
 
 add_library(treeler ${treeler_SRC})
 set_target_properties(treeler PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(treeler ${ZLIB_LIBRARIES})
+target_link_libraries(treeler ZLIB::ZLIB)
 target_include_directories(treeler PUBLIC .) # TODO: Here we are also including 'main'
 
 install(TARGETS treeler

--- a/src/libtreeler/main/CMakeLists.txt
+++ b/src/libtreeler/main/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 add_executable(treeler_bin ${treeler_main_SRC})
 target_include_directories(treeler_bin PRIVATE .)
-target_link_libraries(treeler_bin treeler ${ZLIB_LIBRARIES})
+target_link_libraries(treeler_bin treeler ZLIB::ZLIB)
 set_target_properties(treeler_bin PROPERTIES OUTPUT_NAME treeler)
 
 install(TARGETS treeler_bin

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,9 +1,4 @@
 
-# Dependencies
-include_directories(${Boost_INCLUDE_DIR})
-include_directories(${ICU_INCLUDE_DIRS})
-include_directories(${ZLIB_INCLUDE_DIRS})
-
 if (WIN32)
   # compiler defintions for windows
   add_definitions(-D_CRT_SECURE_NO_WARNINGS=1 -D_CRT_NONSTDC_NO_DEPRECATE=1 -DNOMINMAX -DNDEBUG=1 -DWIN32=1 -D_CONSOLE=1)

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-include_directories(${Boost_INCLUDE_DIR})
-include_directories(${ICU_INCLUDE_DIRS})
-
 if (WIN32)
   # compiler defintions for windows
   add_definitions(-D_CRT_SECURE_NO_WARNINGS=1 -D_CRT_NONSTDC_NO_DEPRECATE=1 -DNOMINMAX -DNDEBUG=1 -DWIN32=1 -D_CONSOLE=1)


### PR DESCRIPTION
Using CMake targets, information about include directories, libraries, link flags,... is contained in the target and added to the dependencies.

One doubt I have:
 * Not sure if `Boost_LIBRARIES` variable already contains the target. If not, we should use `Boost::program_options Boost::regex Boost:serialization` (or the required targets for each library).

As the other PR, I hope this is not breaking existing builds, if so, let me know how to reproduce them and I will work on these changes.