### PR TITLE
Add cmath include to summarizer.cc

### DIFF
--- a/src/libfreeling/summarizer/summarizer.cc
+++ b/src/libfreeling/summarizer/summarizer.cc
@@ -26,6 +26,7 @@
 //
 ////////////////////////////////////////////////////////////////
 
+#include <cmath>
 
 #include "freeling/morfo/summarizer.h"
 #include "freeling/morfo/configfile.h"


### PR DESCRIPTION
Added `#include <cmath>` as `pow` and `sqrt` functions require it.