### PR TITLE
Fix project build

### DIFF
--- a/src/libtreeler/treeler/base/scores.h
+++ b/src/libtreeler/treeler/base/scores.h
@@ -82,7 +82,7 @@ namespace treeler {
   template <typename X, typename R>
   class ConstantScores : public BaseScores<ConstantScores<X,R>> {
   private:
-    const double _s; 
+    double _s; 
     bool  _random; 
   public:
 


### PR DESCRIPTION
This PR fixes `make install` by removing `const` from `double _s` in `scores.h`.

The variable `_s` is used in the function `void set_score(double s) { _s = s; }`.

When `const` was used, the build failed during `make install`.